### PR TITLE
Ensure IPv6 address ending on IPv4 is created correctly

### DIFF
--- a/value-provider-core/src/main/java/com/tngtech/valueprovider/ValueProvider.java
+++ b/value-provider-core/src/main/java/com/tngtech/valueprovider/ValueProvider.java
@@ -734,8 +734,7 @@ public class ValueProvider {
      * @param elements the elements to draw from.
      * @return the drawn elements (none / some / all).
      */
-    @SafeVarargs
-    final public <T> Collection<T> someOf(T... elements) {
+    @SafeVarargs final public <T> Collection<T> someOf(T... elements) {
         return someOf(asList(elements));
     }
 
@@ -898,7 +897,7 @@ public class ValueProvider {
         for (int i = 0; i < 6; i++) {
             blocks.add(createIPv6Block());
         }
-        blocks.add(ipAddress());
+        blocks.add(ipV4Address());
         return blocks;
     }
 


### PR DESCRIPTION
When creating an IPv6 address ending on an IPv4 address do not call random IP address generation but use IPv4 explicitly to avoid concatenating two partial IPv6 addresses.