### PR TITLE
Move dependencies to version catalog

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -37,27 +37,6 @@ ext {
             url : 'https://www.tngtech.com/'
     ]
 
-    dependency = [
-            apache_commons       : [group: 'org.apache.commons', name: 'commons-lang3', version: '3.14.0'],
-            guava                : [group: 'com.google.guava', name: 'guava', version: '33.0.0-jre'],
-            slf4j_api            : [group: 'org.slf4j', name: 'slf4j-api', version: '2.0.16'],
-            lombok               : [group: 'org.projectlombok', name: 'lombok', version: '1.18.30'],
-
-            junit4               : [group: 'junit', name: 'junit', version: '4.13.2'],
-            junit4_dataprovider  : [group: 'com.tngtech.junit.dataprovider', name: 'junit4-dataprovider', version: '2.10'],
-            junit5_dataprovider  : [group: 'com.tngtech.junit.dataprovider', name: 'junit-jupiter-dataprovider', version: '2.10'],
-            assertj_core         : [group: 'org.assertj', name: 'assertj-core', version: '3.25.3'],
-            mockito              : [group: 'org.mockito', name: 'mockito-core', version: '5.10.0'],
-            slf4j_simple         : [group: 'org.slf4j', name: 'slf4j-simple', version: '2.0.16'],
-
-            junit4_engine        : [group: 'org.junit.vintage', name: 'junit-vintage-engine', version: '5.10.2'],
-            junit_jupiter_api    : [group: 'org.junit.jupiter', name: 'junit-jupiter-api', version: '5.10.2'],
-            junit_jupiter_engine : [group: 'org.junit.jupiter', name: 'junit-jupiter-engine', version: '5.10.2'],
-            junit_jupiter_params : [group: 'org.junit.jupiter', name: 'junit-jupiter-params', version: '5.10.2'],
-            junit_platform_runner: [group: 'org.junit.platform', name: 'junit-platform-runner', version: '1.10.2'],
-            junit_jupiter_testkit: [group: 'org.junit.platform', name: 'junit-platform-testkit', version: '1.10.2']
-    ]
-
     postfixedJar = { File jarFile, String postfix ->
         new File(jarFile.parentFile, jarFile.name.replaceAll(/\.jar$/, "-${postfix}.jar"))
     }
@@ -106,16 +85,16 @@ subprojects {
     targetCompatibility = '1.8'
 
     dependencies {
-        implementation dependency.apache_commons
-        implementation dependency.guava
-        implementation dependency.slf4j_api
+        implementation libs.apache.commons
+        implementation libs.guava
+        implementation libs.slf4j.api
 
-        testImplementation dependency.assertj_core
-        testImplementation dependency.junit4
-        testImplementation dependency.junit_jupiter_api
+        testImplementation libs.assertj.core
+        testImplementation libs.junit4
+        testImplementation libs.junit.jupiter.api
 
         // hint: activate (debug) logging via system property -Dorg.slf4j.simpleLogger.defaultLogLevel=debug
-        testRuntimeOnly dependency.slf4j_simple
+        testRuntimeOnly libs.slf4j.simple
     }
 
     repositories {

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -1,9 +1,9 @@
 dependencies {
-    testImplementation dependency.junit_jupiter_api
-    testCompileOnly dependency.lombok
-    testAnnotationProcessor dependency.lombok
+    testImplementation libs.junit.jupiter.api
+    testCompileOnly libs.lombok
+    testAnnotationProcessor libs.lombok
 
-    testRuntimeOnly dependency.junit_jupiter_engine
+    testRuntimeOnly libs.junit.jupiter.engine
 }
 
 task testJar(type: Jar) {

--- a/example/build.gradle
+++ b/example/build.gradle
@@ -1,10 +1,10 @@
 dependencies {
-    compileOnly dependency.lombok
-    annotationProcessor dependency.lombok
+    compileOnly libs.lombok
+    annotationProcessor libs.lombok
     implementation project(':core')
 
-    testImplementation dependency.junit_jupiter_api
+    testImplementation libs.junit.jupiter.api
     testImplementation project(':junit5')
 
-    testRuntimeOnly dependency.junit_jupiter_engine
+    testRuntimeOnly libs.junit.jupiter.engine
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,0 +1,17 @@
+[libraries]
+apache_commons = { group = "org.apache.commons", name = "commons-lang3", version = "3.14.0" }
+guava = { group = "com.google.guava", name = "guava", version = "33.0.0-jre" }
+slf4j_api = { group = "org.slf4j", name = "slf4j-api", version = "2.0.16" }
+lombok = { group = "org.projectlombok", name = "lombok", version = "1.18.30" }
+
+junit4 = { group = "junit", name = "junit", version = "4.13.2" }
+junit4_dataprovider = { group = "com.tngtech.junit.dataprovider", name = "junit4-dataprovider", version = "2.10" }
+junit5_dataprovider = { group = "com.tngtech.junit.dataprovider", name = "junit-jupiter-dataprovider", version = "2.10" }
+assertj_core = { group = "org.assertj", name = "assertj-core", version = "3.25.3" }
+slf4j_simple = { group = "org.slf4j", name = "slf4j-simple", version = "2.0.16" }
+
+junit4_engine = { group = "org.junit.vintage", name = "junit-vintage-engine", version = "5.10.2" }
+junit_jupiter_api = { group = "org.junit.jupiter", name = "junit-jupiter-api", version = "5.10.2" }
+junit_jupiter_engine = { group = "org.junit.jupiter", name = "junit-jupiter-engine", version = "5.10.2" }
+junit_jupiter_params = { group = "org.junit.jupiter", name = "junit-jupiter-params", version = "5.10.2" }
+junit_jupiter_testkit = { group = "org.junit.platform", name = "junit-platform-testkit", version = "1.10.2" }

--- a/junit4/build.gradle
+++ b/junit4/build.gradle
@@ -1,11 +1,11 @@
 dependencies {
-    implementation dependency.junit4
+    implementation libs.junit4
 
     implementation project(':core')
 
     testImplementation project(path: ':core', configuration: 'tests')
-    testImplementation dependency.junit4_dataprovider
-    testRuntimeOnly dependency.junit4_engine
+    testImplementation libs.junit4.dataprovider
+    testRuntimeOnly libs.junit4.engine
 }
 test {
     // set via -DrandomFailureForDataProviderTests=true on the gradle commandline to provoke random failures

--- a/junit5/build.gradle
+++ b/junit5/build.gradle
@@ -1,12 +1,12 @@
 dependencies {
-    implementation dependency.junit_jupiter_api
+    implementation libs.junit.jupiter.api
 
     implementation project(':core')
 
     testImplementation project(path: ':core', configuration: 'tests')
-    testImplementation dependency.junit5_dataprovider
-    testImplementation dependency.junit_jupiter_params
-    testImplementation dependency.junit_jupiter_testkit
+    testImplementation libs.junit5.dataprovider
+    testImplementation libs.junit.jupiter.params
+    testImplementation libs.junit.jupiter.testkit
 
-    testRuntimeOnly dependency.junit_jupiter_engine
+    testRuntimeOnly libs.junit.jupiter.engine
 }


### PR DESCRIPTION
Dependabot does not understand the previously used properties notation and thus does not update dependencies automatically.