### PR TITLE
Switch to Sonatype OSSRH Staging API Service for publishing

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -7,11 +7,13 @@ buildscript {
 
     dependencies {
         classpath 'com.github.jk1:gradle-license-report:2.9'
-    }
-}
+        // com.vanniktech.maven.publish plugin is not compatible with Java 8,
+        // so the standard 'plugins {...}' approach can't be used, but the dependency must be controlled via a build property
+        if (project.hasProperty('release')) {
+            classpath "com.vanniktech.maven.publish:com.vanniktech.maven.publish.gradle.plugin:0.34.0"
+        }
 
-plugins {
-    id "io.github.gradle-nexus.publish-plugin" version "2.0.0" apply true
+    }
 }
 
 def appAndSourceUrl = 'https://github.com/TNG/value-provider'
@@ -108,161 +110,153 @@ subprojects {
 
 ext.isReleaseVersion = !project.version.endsWith("-SNAPSHOT")
 
-// respective username and password can be configured in ~/.gradle/gradle.properties
-nexusPublishing {
-    packageGroup = 'com.tngtech'
-    repositories {
-        sonatype {
-            username = findProperty("sonatypeUsername")
-            password = findProperty("sonatypePassword")
-        }
-    }
-}
-releaseProjects*.with {
-    apply plugin: "maven-publish"
-    apply plugin: "signing"
+// duplication seems inevitable, as buildscript {...} does not support variables
+def isReleaseBuild = project.hasProperty('release')
 
-    tasks.withType(GenerateModuleMetadata) {
-        enabled = false // the meta-data does not match the way the Maven artifacts are composed and thus is broken
-    }
+if (isReleaseBuild) {
+    releaseProjects*.with {
+        apply plugin: 'com.vanniktech.maven.publish'
+        apply plugin: 'signing'
 
-    java {
-        withJavadocJar()
-        withSourcesJar()
-    }
-
-    // fix for broken java doc generation when using html tags in javadoc
-    if (JavaVersion.current().isJava8Compatible()) {
-        allprojects {
-            tasks.withType(Javadoc) {
-                options.addStringOption('Xdoclint:none', '-quiet')
-            }
-        }
-    }
-    if (JavaVersion.current().isJava9Compatible()) {
-        allprojects {
-            tasks.withType(Javadoc) {
-                options.addBooleanOption('html5', true)
-            }
-        }
-    }
-
-    project(":core") {
-        archivesBaseName = 'value-provider-core'
-        description = app.description
-    }
-
-    project(":junit4") {
-        archivesBaseName = 'value-provider-junit4'
-        description = 'JUnit 4 test infrastructure to reproduce random test data in case of test failures.'
-    }
-
-    project(":junit5") {
-        archivesBaseName = 'value-provider-junit5'
-        description = 'JUnit 5 test infrastructure to reproduce random test data in case of test failures.'
-    }
-
-    project(":example") {
-        archivesBaseName = 'value-provider-example'
-        description = 'Examples for test data factories using the value-provider library.'
-    }
-
-    tasks.withType(Jar) {
-        from(rootProject.rootDir) {
-            include("LICENSE", "NOTICE")
-            into("META-INF")
+        tasks.withType(GenerateModuleMetadata) {
+            enabled = false // the meta-data does not match the way the Maven artifacts are composed and thus is broken
         }
 
-        manifest {
-            def title = project.archivesBaseName
-            def now = java.time.LocalDate.now()
-            def today = now.format(java.time.format.DateTimeFormatter.ofPattern("yyyy-MM-dd"))
-            def companyName = company.name
-            def copyright = "${now.year} ${companyName}"
-
-            attributes(
-                    'Built-By': "Gradle ${gradle.gradleVersion}",
-                    'Built-Date': today,
-                    'Specification-Title': project.archivesBaseName,
-                    'Specification-Version': archiveVersion,
-                    'Specification-Vendor': companyName,
-                    'Implementation-Title': title,
-                    'Implementation-Version': archiveVersion,
-                    'Implementation-Vendor': company.name,
-                    'Issue-Tracker': "https://github.com/TNG/value-provider/issues",
-                    'Documentation-URL': "https://github.com/TNG/value-provider",
-                    'Copyright': copyright,
-                    'License': app.license.name,
-            )
-        }
-    }
-    tasks.withType(AbstractPublishToMaven) {
-        it.dependsOn(build)
-    }
-    tasks.withType(PublishToMavenRepository) {
-        it.doFirst {
-            assert !gradle.startParameter.isParallelProjectExecutionEnabled():
-                    'uploading archives with parallel execution seems to lead to broken uploads in Sonatype Nexus'
-        }
-    }
-
-    publishing {
-        publications {
-            mavenJava(MavenPublication) {
-                artifactId = project.archivesBaseName
-                from components.java
-                pom {
-                    name = project.archivesBaseName
-                    packaging = "jar"
-                    description = project.description
-                    url = app.urls.entry
-
-                    developers {
-                        developer {
-                            id = 'stefanhechtltng'
-                            name = 'Stefan Hechtl'
-                            email = 'stefan.hechtl@tngtech.com'
-                        }
-                        developer {
-                            id = 'jonashoef'
-                            name = 'Jonas Höf'
-                            email = 'jonas.hoef@tngtech.com'
-                        }
-                    }
-
-                    licenses {
-                        license {
-                            name = app.license.name
-                            url = app.license.url
-                            distribution = 'repo'
-                        }
-                    }
-
-                    organization {
-                        name = company.name
-                        url = company.url
-                    }
-
-                    scm {
-                        url = app.urls.source
-                        connection = "scm:${app.gitRepo}"
-                        developerConnection = "scm:${app.gitRepo}"
-                    }
+        // fix for broken java doc generation when using html tags in javadoc
+        if (JavaVersion.current().isJava8Compatible()) {
+            allprojects {
+                tasks.withType(Javadoc) {
+                    options.addStringOption('Xdoclint:none', '-quiet')
                 }
             }
         }
-    }
-
-    signing {
-        // requires gradle.properties, see http://www.gradle.org/docs/current/userguide/signing_plugin.html
-        required {
-            isReleaseVersion && gradle.taskGraph.hasTask('publish')
+        if (JavaVersion.current().isJava9Compatible()) {
+            allprojects {
+                tasks.withType(Javadoc) {
+                    options.addBooleanOption('html5', true)
+                }
+            }
         }
-        def signingKey = findProperty("signingKey")
-        def signingPassword = findProperty("signingPassword")
-        useInMemoryPgpKeys(signingKey, signingPassword)
-        sign publishing.publications.mavenJava
+
+        project(":core") {
+            archivesBaseName = 'value-provider-core'
+            description = app.description
+        }
+
+        project(":junit4") {
+            archivesBaseName = 'value-provider-junit4'
+            description = 'JUnit 4 test infrastructure to reproduce random test data in case of test failures.'
+        }
+
+        project(":junit5") {
+            archivesBaseName = 'value-provider-junit5'
+            description = 'JUnit 5 test infrastructure to reproduce random test data in case of test failures.'
+        }
+
+        project(":example") {
+            archivesBaseName = 'value-provider-example'
+            description = 'Examples for test data factories using the value-provider library.'
+        }
+
+        tasks.withType(Jar) {
+            from(rootProject.rootDir) {
+                include("LICENSE", "NOTICE")
+                into("META-INF")
+            }
+
+            manifest {
+                def title = project.archivesBaseName
+                def now = java.time.LocalDate.now()
+                def today = now.format(java.time.format.DateTimeFormatter.ofPattern("yyyy-MM-dd"))
+                def companyName = company.name
+                def copyright = "${now.year} ${companyName}"
+
+                attributes(
+                        'Built-By': "Gradle ${gradle.gradleVersion}",
+                        'Built-Date': today,
+                        'Specification-Title': project.archivesBaseName,
+                        'Specification-Version': archiveVersion,
+                        'Specification-Vendor': companyName,
+                        'Implementation-Title': title,
+                        'Implementation-Version': archiveVersion,
+                        'Implementation-Vendor': company.name,
+                        'Issue-Tracker': "https://github.com/TNG/value-provider/issues",
+                        'Documentation-URL': "https://github.com/TNG/value-provider",
+                        'Copyright': copyright,
+                        'License': app.license.name,
+                )
+            }
+        }
+        tasks.withType(AbstractPublishToMaven) {
+            it.dependsOn(build)
+        }
+        tasks.withType(PublishToMavenRepository) {
+            it.doFirst {
+                assert !gradle.startParameter.isParallelProjectExecutionEnabled():
+                        'uploading archives with parallel execution seems to lead to broken uploads in Maven Central'
+            }
+        }
+
+        mavenPublishing {
+            // true -> automatically publish after uploading
+            publishToMavenCentral(true)
+            signAllPublications()
+
+            coordinates(
+                    project.group,
+                    project.archivesBaseName,
+                    project.version.toString()
+            )
+
+            pom {
+                name = project.archivesBaseName
+                packaging = "jar"
+                description = project.description
+                url = app.urls.entry
+
+                developers {
+                    developer {
+                        id = 'stefanhechtltng'
+                        name = 'Stefan Hechtl'
+                        email = 'stefan.hechtl@tngtech.com'
+                    }
+                    developer {
+                        id = 'jonashoef'
+                        name = 'Jonas Höf'
+                        email = 'jonas.hoef@tngtech.com'
+                    }
+                }
+
+                licenses {
+                    license {
+                        name = app.license.name
+                        url = app.license.url
+                        distribution = 'repo'
+                    }
+                }
+
+                organization {
+                    name = company.name
+                    url = company.url
+                }
+
+                scm {
+                    url = app.urls.source
+                    connection = "scm:${app.gitRepo}"
+                    developerConnection = "scm:${app.gitRepo}"
+                }
+            }
+        }
+
+        signing {
+            // requires gradle.properties, see http://www.gradle.org/docs/current/userguide/signing_plugin.html
+            required {
+                isReleaseVersion && gradle.taskGraph.hasTask('publish')
+            }
+            def signingKey = findProperty("signingKey")
+            def signingPassword = findProperty("signingPassword")
+            useInMemoryPgpKeys(signingKey, signingPassword)
+        }
     }
 }
-
 apply plugin: 'com.github.jk1.dependency-license-report'


### PR DESCRIPTION
* This is necessary, as the previously used publishing procedure is no longer supported.
* The dependency to the com.vanniktech.maven.publish plugin must be controlled via a Gradle property that is only set for release/publish builds, but not for CI. The plugin requires Java 11, but the CI should be run for Java 8 as well.
* The secrets for publishing to Maven Central are provided directly as Gradle properties so that they can be passed to gradlew without any modification. It should be noted that this requires a respective adaptation of the release.yaml in the value-provider-release repo.