### PR TITLE
Restrict Apache commons-lang3 to a testImplementation dependency

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -87,10 +87,10 @@ subprojects {
     targetCompatibility = '1.8'
 
     dependencies {
-        implementation libs.apache.commons
         implementation libs.guava
         implementation libs.slf4j.api
 
+        testImplementation libs.apache.commons
         testImplementation libs.assertj.core
         testImplementation libs.junit4
         testImplementation libs.junit.jupiter.api


### PR DESCRIPTION
It will then no longer be present in any published value-provider pom.xml