### PR TITLE
Remove zero-padding from IPv4 address segments

### DIFF
--- a/core/src/main/java/com/tngtech/valueprovider/AbstractValueProvider.java
+++ b/core/src/main/java/com/tngtech/valueprovider/AbstractValueProvider.java
@@ -1371,10 +1371,9 @@ public abstract class AbstractValueProvider<VP extends AbstractValueProvider<VP>
      * @return the generated address.
      */
     public String ipV4Address() {
-        DecimalFormat threeDigits = new DecimalFormat("000");
         List<String> parts = new ArrayList<>();
         for (int i = 0; i < 4; i++) {
-            parts.add(threeDigits.format(intNumber(1, 255)));
+            parts.add(String.valueOf(intNumber(1, 255)));
         }
         return parts.stream()
                 .map(String::toString)


### PR DESCRIPTION
Depending on how such an IPv4 address is parsed, leading zeros might cause the segment to be interpreted as octal notation. While such addresses might be desired to test such edge cases, I think they shouldn't be produced by default.